### PR TITLE
Added remaining Unicode fractions

### DIFF
--- a/lib/Lingua/EN/Fractions.pm
+++ b/lib/Lingua/EN/Fractions.pm
@@ -29,10 +29,15 @@ my %unicode =
     '⅘' => '4/5',
     '⅙' => '1/6',
     '⅚' => '5/6',
+    '⅐' => '1/7',
     '⅛' => '1/8',
     '⅜' => '3/8',
     '⅝' => '5/8',
     '⅞' => '7/8',
+    '⅑' => '1/9',
+    '⅒' => '1/10',
+    '⅟' => '1/',
+    '↉' => '0/3',
     '⁄' => '/',     # FRACTION SLASH (U+2044)
     '−' => '-',     # MINUS SIGN (U+2212)
 );
@@ -86,7 +91,7 @@ sub fraction2words
         $phrase .= 'minus ' if $negate;
         $phrase .= num2en($wholepart).' and ' if $wholepart;
         $phrase .= "$numerator_as_words $denominator_as_words";
-        $phrase .= 's' if $numerator > 1;
+        $phrase .= 's' if $numerator != 1;
         return $phrase;
     }
 

--- a/t/06-unicode.t
+++ b/t/06-unicode.t
@@ -29,6 +29,10 @@ my @TESTS =
     # These use the Unicode character MINUS SIGN (U+2212)
     [   ['−5/6'],       'minus five sixths'         ],
     [   ['−⅚'],         'minus five sixths'         ],
+
+    [   ['⅑'],          'one ninth'                 ], 
+    [   ['⅟10'],        'one tenth'                 ],
+    [   ['↉'],          'zero thirds'               ], 
 );
 
 plan tests => int(@TESTS);


### PR DESCRIPTION
I searched UnicodeData.txt (version 9.0.0) [1] for "VULGAR FRACTION"
and found these additions.

I added some tests and altered a line for the sake of "0/3" which
should be "zero thirds" with an s.

[1] http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt
