### PR TITLE
Support English variants

### DIFF
--- a/lib/Lingua/EN/Fractions.pm
+++ b/lib/Lingua/EN/Fractions.pm
@@ -43,9 +43,18 @@ my %unicode =
 );
 my $unicode_regexp = join('|', keys %unicode);
 
+my %english =
+(
+    American => { minus => 'negative' },
+    British => { minus => 'minus' },
+);
+
 sub fraction2words
 {
-    my $number = shift;
+    my ($number, $variant) = @_;
+    $variant ||= 'British';
+    die qq(Unknown variant "$variant".\n) unless exists $english{$variant};
+
     my $fraction = qr|
                         ^
                         (\s*-)?
@@ -88,7 +97,7 @@ sub fraction2words
         };
         my $phrase = '';
         
-        $phrase .= 'minus ' if $negate;
+        $phrase .= $english{$variant}{minus} . ' ' if $negate;
         $phrase .= num2en($wholepart).' and ' if $wholepart;
         $phrase .= "$numerator_as_words $denominator_as_words";
         $phrase .= 's' if $numerator != 1;
@@ -166,6 +175,14 @@ As of version 0.06, you an also use the Unicode MINUS SIGN:
 
 At the moment, the DIVISION SLASH character isn't handled.
 Feel free to tell me if you think I got that wrong.
+
+=head2 British versus American variants
+
+American English uses "negative" instead of British "minus". The
+second optional argument to fraction2words can be set to the variant you want:
+
+ fraction2words('-3/5', 'British');   # "minus three fifths" (same as default)
+ fraction2words('-3/5', 'American');  # "negative three fifths"
 
 =head2 Working with Number::Fraction
 

--- a/t/07-variant.t
+++ b/t/07-variant.t
@@ -1,0 +1,48 @@
+#! perl
+use 5.006;
+use warnings;
+use strict;
+
+use Test::More 0.88;
+use Lingua::EN::Fractions qw/ fraction2words /;
+
+plan tests => 5;
+
+is
+(
+    fraction2words('-2/3', 'British'),
+    'minus two thirds',
+    'british works'
+);
+
+is
+(
+    fraction2words('-2/3'),
+    'minus two thirds',
+    'british is the default'
+);
+
+is
+(
+    fraction2words('-2/3', 'American'),
+    'negative two thirds',
+    'american works'
+);
+
+
+my $wrong = eval
+{
+    fraction2words('-2/3', 'Australian');
+    1
+};
+ok
+(
+    ! defined $wrong,
+    'unknown dies'
+);
+like
+(
+    $@,
+    qr/^Unknown variant "Australian"\.$/,
+    'correct exception'
+);


### PR DESCRIPTION
"minus" in British English is "negative" in American English.